### PR TITLE
MODLD-962: Update label of the Title resource to include part number and part name

### DIFF
--- a/src/main/java/org/folio/rdf4ld/util/ResourceUtil.java
+++ b/src/main/java/org/folio/rdf4ld/util/ResourceUtil.java
@@ -13,10 +13,8 @@ import static org.folio.ld.dictionary.PropertyDictionary.GENERAL_SUBDIVISION;
 import static org.folio.ld.dictionary.PropertyDictionary.GEOGRAPHIC_SUBDIVISION;
 import static org.folio.ld.dictionary.PropertyDictionary.LABEL;
 import static org.folio.ld.dictionary.PropertyDictionary.LINK;
-import static org.folio.ld.dictionary.PropertyDictionary.MAIN_TITLE;
 import static org.folio.ld.dictionary.PropertyDictionary.NAME;
 import static org.folio.ld.dictionary.PropertyDictionary.RESOURCE_PREFERRED;
-import static org.folio.ld.dictionary.PropertyDictionary.SUBTITLE;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.FAMILY;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.FORM;
 import static org.folio.ld.dictionary.ResourceTypeDictionary.IDENTIFIER;
@@ -69,8 +67,7 @@ public class ResourceUtil {
       .filter(e -> e.getPredicate() == PredicateDictionary.TITLE)
       .map(ResourceEdge::getTarget)
       .filter(t -> t.getTypes().contains(ResourceTypeDictionary.TITLE))
-      .map(Resource::getDoc)
-      .map(d -> getPropertiesString(d, MAIN_TITLE, SUBTITLE))
+      .map(Resource::getLabel)
       .findFirst()
       .orElse("");
   }

--- a/src/main/resources/mappingProfile/bibframe2.0/title/title.json
+++ b/src/main/resources/mappingProfile/bibframe2.0/title/title.json
@@ -32,7 +32,9 @@
     ],
     "label": [
       "MAIN_TITLE",
-      "SUBTITLE"
+      "SUBTITLE",
+      "PART_NUMBER",
+      "PART_NAME"
     ]
   }
 }

--- a/src/main/resources/mappingProfile/bibframe2.0/title/title_parallel.json
+++ b/src/main/resources/mappingProfile/bibframe2.0/title/title_parallel.json
@@ -40,7 +40,9 @@
     ],
     "label": [
       "MAIN_TITLE",
-      "SUBTITLE"
+      "SUBTITLE",
+      "PART_NUMBER",
+      "PART_NAME"
     ]
   }
 }

--- a/src/main/resources/mappingProfile/bibframe2.0/title/title_variant.json
+++ b/src/main/resources/mappingProfile/bibframe2.0/title/title_variant.json
@@ -45,7 +45,9 @@
     ],
     "label": [
       "MAIN_TITLE",
-      "SUBTITLE"
+      "SUBTITLE",
+      "PART_NUMBER",
+      "PART_NAME"
     ]
   }
 }

--- a/src/test/java/org/folio/rdf4ld/mapper/unit/monograph/InstanceRdfMapperUnitTest.java
+++ b/src/test/java/org/folio/rdf4ld/mapper/unit/monograph/InstanceRdfMapperUnitTest.java
@@ -39,7 +39,8 @@ class InstanceRdfMapperUnitTest {
     var resourceMapping = mock(ResourceMapping.class);
     var mappedResource = new Resource()
       .setId(123L);
-    mappedResource.addOutgoingEdge(new ResourceEdge(mappedResource, createPrimaryTitle(""), TITLE));
+    var titleResource = createPrimaryTitle("").setLabel("title label");
+    mappedResource.addOutgoingEdge(new ResourceEdge(mappedResource, titleResource, TITLE));
     doReturn(of(mappedResource)).when(baseRdfMapperUnit).mapToLd(model, resource, resourceMapping, null);
     long newId = 789L;
     doReturn(newId).when(hashService).hash(mappedResource);
@@ -50,7 +51,6 @@ class InstanceRdfMapperUnitTest {
     // then
     assertThat(result).isPresent()
       .hasValueSatisfying(i -> assertThat(i.getId()).isEqualTo(newId))
-      .hasValueSatisfying(i -> assertThat(i.getLabel())
-        .isEqualTo("Title mainTitle 1, Title mainTitle 2, Title subTitle 1, Title subTitle 2"));
+      .hasValueSatisfying(i -> assertThat(i.getLabel()).isEqualTo(titleResource.getLabel()));
   }
 }

--- a/src/test/java/org/folio/rdf4ld/mapper/unit/monograph/WorkRdfMapperUnitTest.java
+++ b/src/test/java/org/folio/rdf4ld/mapper/unit/monograph/WorkRdfMapperUnitTest.java
@@ -46,7 +46,8 @@ class WorkRdfMapperUnitTest {
     var mapping = mock(ResourceMapping.class);
     var mappedResource = new Resource()
       .setId(123L);
-    mappedResource.addOutgoingEdge(new ResourceEdge(mappedResource, createPrimaryTitle(""), TITLE));
+    var titleResource = createPrimaryTitle("").setLabel("title label");
+    mappedResource.addOutgoingEdge(new ResourceEdge(mappedResource, titleResource, TITLE));
     doReturn(of(mappedResource)).when(baseRdfMapperUnit).mapToLd(model, resource, mapping, null);
     long newId = 789L;
     doReturn(newId).when(hashService).hash(mappedResource);
@@ -63,7 +64,6 @@ class WorkRdfMapperUnitTest {
     // then
     assertThat(result).isPresent()
       .hasValueSatisfying(w -> assertThat(w.getId()).isEqualTo(newId))
-      .hasValueSatisfying(w -> assertThat(w.getLabel())
-        .isEqualTo("Title mainTitle 1, Title mainTitle 2, Title subTitle 1, Title subTitle 2"));
+      .hasValueSatisfying(w -> assertThat(w.getLabel()).isEqualTo(titleResource.getLabel()));
   }
 }

--- a/src/test/java/org/folio/rdf4ld/test/TestUtil.java
+++ b/src/test/java/org/folio/rdf4ld/test/TestUtil.java
@@ -157,7 +157,9 @@ public class TestUtil {
 
   public static String getTitleLabel(String prefix, String titleType) {
     return prefix + titleType + " mainTitle 1, " + prefix + titleType + " mainTitle 2, "
-      + prefix + titleType + " subTitle 1, " + prefix + titleType + " subTitle 2";
+      + prefix + titleType + " subTitle 1, " + prefix + titleType + " subTitle 2, "
+      + prefix + titleType + " partNumber 1, " + prefix + titleType + " partNumber 2, "
+      + prefix + titleType + " partName 1, " + prefix + titleType + " partName 2";
   }
 
   public static void validateResourceWithGivenEdges(Resource resource, ResourceEdge... edges) {

--- a/src/test/java/org/folio/rdf4ld/util/ResourceUtilTest.java
+++ b/src/test/java/org/folio/rdf4ld/util/ResourceUtilTest.java
@@ -2,11 +2,9 @@ package org.folio.rdf4ld.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.ld.dictionary.PropertyDictionary.LABEL;
-import static org.folio.ld.dictionary.PropertyDictionary.MAIN_TITLE;
 import static org.folio.ld.dictionary.PropertyDictionary.MISC_INFO;
 import static org.folio.ld.dictionary.PropertyDictionary.NAME;
 import static org.folio.ld.dictionary.PropertyDictionary.RESOURCE_PREFERRED;
-import static org.folio.ld.dictionary.PropertyDictionary.SUBTITLE;
 import static org.folio.ld.dictionary.PropertyDictionary.SYSTEM_DETAILS;
 import static org.folio.rdf4ld.test.MonographUtil.getJsonNode;
 
@@ -54,10 +52,7 @@ class ResourceUtilTest {
     // given
     var target = new Resource();
     target.setTypes(Set.of(ResourceTypeDictionary.TITLE));
-    target.setDoc(getJsonNode(Map.of(
-      MAIN_TITLE.getValue(), List.of("Main Title"),
-      SUBTITLE.getValue(), List.of("Subtitle"))
-    ));
+    target.setLabel("title label");
     var edge = new ResourceEdge(new Resource(), target, PredicateDictionary.TITLE);
     var resource = new Resource();
     resource.setOutgoingEdges(Set.of(edge));
@@ -66,7 +61,7 @@ class ResourceUtilTest {
     var result = ResourceUtil.getPrimaryMainTitle(resource);
 
     // then
-    assertThat(result).isEqualTo("Main Title, Subtitle");
+    assertThat(result).isEqualTo(target.getLabel());
   }
 
   @Test


### PR DESCRIPTION
Update label generation logic to be consistent with this PR -> https://github.com/folio-org/lib-linked-data-marc4ld/pull/194/changes#diff-4159f09976c288b812ddeffcbe5b8b06e36dee76ecf3ffcb879a43945befb296R173

As part of [this](https://folio-org.atlassian.net/browse/MODLD-913) story we will update lib-linked-data-rdf4ld to use the common Label service 